### PR TITLE
Set up GAE

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,9 @@
-FROM python:rc-stretch
-ADD . /app
+FROM python:latest
+RUN apt -y update && apt -y install libffi-dev
+ADD ./requirements.txt /app/requirements.txt
 WORKDIR /app
-RUN pip install -r requirements.txt
-ENTRYPOINT ["python"]
+RUN pip3 install -r requirements.txt
+ADD . /app
+#ENTRYPOINT ["python3"]
 ENV PORT=80
 CMD gunicorn -w 4 -b 0.0.0.0:$PORT wsgi

--- a/api.py
+++ b/api.py
@@ -409,7 +409,7 @@ def send():
 
 
 if __name__ == '__main__':
-	app.run(host='0.0.0.0')
+    app.run(host='0.0.0.0')
 
     #Run tests
     auth.run_tests()

--- a/app.yaml
+++ b/app.yaml
@@ -1,0 +1,4 @@
+runtime: python37
+
+entrypoint: gunicorn -w 2 -b 0.0.0.0:$PORT wsgi
+#entrypoint: python3 api.py

--- a/appengine_config.py
+++ b/appengine_config.py
@@ -1,0 +1,3 @@
+from google.appengine.ext import vendor
+
+vendor.add(os.path.join(os.path.dirname(os.path.realpath(__file__)), 'lib'))


### PR DESCRIPTION
This PR creates the `app.yaml` and `appengine_config.py` files that allow us to run the app on Google App Engine. 

It still works with other platforms such as Heroku or Docker, but this gives us more options in case we decide to use GAE.