### PR TITLE
Use serviceutils functions instead of HTTP requests to other services

### DIFF
--- a/api.py
+++ b/api.py
@@ -8,6 +8,7 @@ from services.User import User
 from services.HighLow import HighLow, HighLowList
 from services.EventLogger import EventLogger
 from services.Notifications import Notifications
+import serviceutils
 
 
 #MySQL server configuration
@@ -164,11 +165,8 @@ def get(property):
     #Get token from Authorization
     token = request.headers["Authorization"].replace("Bearer ", "")
 
-    #Create the headers
-    headers = { 'Authorization': "Bearer " + token }
-
     #Make a request to the Auth service
-    token_verification_request = requests.post("http://{}/verify_token".format(auth_service), headers=headers)
+    token_verification_request = serviceutils.verify_token(token)
 
     #Obtain the result as JSON
     result = token_verification_request.json()
@@ -191,11 +189,9 @@ def set(property):
     #Get token from Authorization
     token = request.headers["Authorization"].replace("Bearer ", "")
 
-    #Create the headers
-    headers = { 'Authorization': "Bearer " + token }
-
     #Make a request to the Auth service
-    token_verification_request = requests.post("https://{}/verify_token".format(auth_service), headers=headers)
+    token_verification_request = serviceutils.verify_token(token)
+
 
     #Obtain the result as JSON
     result = token_verification_request.json()
@@ -235,7 +231,7 @@ def sethigh():
     #Verify auth token
     token = request.headers["Authentication"].replace("Bearer ", "")
 
-    verification = Helpers.verify_token(token)
+    verification = serviceutils.verify_token(token)
 
     if 'error' in verification:
         return verification
@@ -261,7 +257,7 @@ def setlow():
     #Verify auth token
     token = request.headers["Authentication"].replace("Bearer ", "")
 
-    verification = Helpers.verify_token(token)
+    verification = serviceutils.verify_token(token)
 
     if 'error' in verification:
         return verification
@@ -287,7 +283,7 @@ def like(highlowid):
     #Verify auth token
 	token = request.headers["Authentication"].replace("Bearer ", "")
 
-	verification = Helpers.verify_token(token)
+	verification = serviceutils.verify_token(token)
 
 	if 'error' in verification:
 		return verification
@@ -308,7 +304,7 @@ def comment(highlowid):
     #Verify auth token
 	token = request.headers["Authentication"].replace("Bearer ", "")
 
-	verification = Helpers.verify_token(token)
+	verification = serviceutils.verify_token(token)
 
 	if 'error' in verification:
 		return verification
@@ -332,7 +328,7 @@ def get_today():
 	#Verify auth token
 	token = request.headers["Authentication"].replace("Bearer ", "")
 
-	verification = Helpers.verify_token(token)
+	verification = serviceutils.verify_token(token)
 
 	if 'error' in verification:
 		return verification
@@ -353,7 +349,7 @@ def get_user():
 	#Verify auth token
 	token = request.headers["Authentication"].replace("Bearer ", "")
 
-	verification = Helpers.verify_token(token)
+	verification = serviceutils.verify_token(token)
 
 	if 'error' in verification:
 		return verification
@@ -412,7 +408,7 @@ def register():
     #Retrieve the token
     token = request.headers["Authorization"].replace("Bearer ", "")
 
-    token_verification = Helpers.verify_token(token)
+    token_verification = serviceutils.verify_token(token)
 
     if 'error' in token_verification:
         return token_verification

--- a/services/Auth.py
+++ b/services/Auth.py
@@ -8,6 +8,7 @@ import datetime
 import time
 import requests
 import Helpers
+import serviceutils
 
 #Email Config
 email_config = Helpers.read_json_from_file("config/email_config.json")
@@ -178,7 +179,6 @@ class Auth:
         expiration = current_time + datetime.timedelta( minutes=expiration_minutes ) #Defaults to six months in the future
 
 
-
         token_payload = {
             "iss": "highlow",
             "exp": time.mktime( expiration.timetuple() ),
@@ -242,9 +242,8 @@ class Auth:
         password_reset_html = password_reset_html.format(user["firstname"], user["lastname"], 'http://' + self.servername + '/password_reset/' + token)
 
         #Send the email
-        requests.post("http://{}/send_html_email".format(email_service) , data = {'email': user["email"], 'message': password_reset_html, 'password': email_config["password"]}) 
+        serviceutils.send_email(user["email"], password_reset_html)
         
-
 
         return "success"
 

--- a/services/HighLow.py
+++ b/services/HighLow.py
@@ -240,8 +240,6 @@ class HighLow:
         conn = pymysql.connect(self.host, self.username, self.password, self.database, cursorclass=pymysql.cursors.DictCursor)
         cursor = conn.cursor()
 
-        #TODO: Should we update the timestamp or not?
-
         cleaned_message = bleach.clean(message)
         cleaned_commentid = bleach.clean(commentid)
         

--- a/serviceutils.py
+++ b/serviceutils.py
@@ -1,0 +1,41 @@
+from services.Auth import Auth
+from services.HLEmail import HLEmail
+import json
+import Helpers
+
+
+#MySQL config
+mysql_config = Helpers.read_json_from_file("config/mysql_config.json")
+
+host = mysql_config["host"]
+username = mysql_config["username"]
+password = mysql_config["password"]
+database = mysql_config["database"]
+
+
+#Auth service
+auth_service = Helpers.service("auth")
+auth = Auth(auth_service, host, username, password, database)
+
+#Email Config
+email_config = Helpers.read_json_from_file("config/email_config.json")
+
+#Email service
+email_service = Helpers.service("email")
+
+hlemail = HLEmail(email_config["email"])
+
+
+def verify_token(token):
+    result = auth.validate_token(token)
+
+    #If token is invalid...
+    if result == "ERROR-INVALID-TOKEN":
+        #Return an error
+        return '{ "error": "' + result + '" }'
+
+    #Otherwise, return the UID
+    return '{ "uid": "' + result + '" }'
+
+def send_email(recipient, message):
+    hlemail.send_html_email(recipient, message, email_config["password"])


### PR DESCRIPTION
I realized there was a problem while I was trying to test some code:

Let's say we run our app on Google App Engine (the current plan). With its current memory constraints, one one instance we can run 2 Gunicorn "workers". Each worker can process 1 request at a time.

When I first combined all the services into one, I kept a lot of the HTTP requests to the other services (such as for sending emails, verifying tokens, etc.).

This led to processes such as this:

1. Server receives HTTP request
2. Server makes HTTP request to itself and waits to get a response
3. When it gets a response, it finishes its tasks and responds to the original client.

That doesn't sound so bad, except that, if you think about it, if each worker can only process 1 request, then the original request takes up an entire worker. Then the second request takes up the second worker. 

Because of  that, we have effectively unnecessarily used up all our resources with a single process.

This PR aims to fix that by removing all unnecessary requests. 