### PR TITLE
Fix IP Address logging for proxy server

### DIFF
--- a/api.py
+++ b/api.py
@@ -74,7 +74,6 @@ with open("resetPassword.html", 'r') as file:
 
 #Create flask app
 app = Flask(__name__)
-app.wsgi_app = ProxyFix(app.wsgi_app)
 
 
 
@@ -683,7 +682,5 @@ def send():
 
 
 if __name__ == '__main__':
+    app.wsgi_app = ProxyFix(app.wsgi_app)
     app.run(host='0.0.0.0')
-
-    #Run tests
-    auth.run_tests()

--- a/api.py
+++ b/api.py
@@ -113,7 +113,7 @@ def sign_up():
 @app.route("/auth/sign_in", methods=["GET", "POST"])
 def sign_in():
 
-    print(request.headers.getlist("X-Forward-For"))
+    print(request.headers.getlist("X-Forwarded-For"))
 
     if request.method == "POST":
 

--- a/api.py
+++ b/api.py
@@ -85,7 +85,7 @@ def get_remote_addr(request):
 
     forward_list = x_forwarded_for.split(",")
 
-    return forward_list[-NUM_PROXIES]
+    return forward_list[ -(NUM_PROXIES + 1) ]
 
 
 
@@ -124,8 +124,6 @@ def sign_up():
 @app.route("/auth/sign_in", methods=["GET", "POST"])
 def sign_in():
 
-    print(get_remote_addr(request))
-
     if request.method == "POST":
 
         result = json.loads( auth.sign_in( request.form["email"], request.form["password"] ) )
@@ -134,7 +132,7 @@ def sign_in():
 
             serviceutils.log_event("sign_in_error", {
                         "error": result["error"],
-                        "ip": request.environ["REMOTE_ADDR"]
+                        "ip": get_remote_addr(request)
                         })
 
         else:
@@ -165,7 +163,7 @@ def password_reset(reset_id):
 
             serviceutils.log_event("error_in_reseting_password", {
                         "error": result["error"],
-                        "ip": request.environ["REMOTE_ADDR"]
+                        "ip": get_remote_addr(request)
                         })
 
         return result
@@ -196,7 +194,7 @@ def verify_token():
         serviceutils.log_event("invalid_token", {
                     "error": result,
                     "false_token": token,
-                    "ip": request.environ["REMOTE_ADDR"]
+                    "ip": get_remote_addr(request)
                     })
 
         return '{ "error": "' + result + '" }'
@@ -605,7 +603,7 @@ def log_event():
 
     if request.form.get(admin_password) != eventlogger_config["admin_password"]:
         serviceutils.log_event("eventlogger_failed_attempt", {
-            "ip": request.remote_addr
+            "ip": get_remote_addr(request)
             })
 
     return event_logger.log_event( request.form["event_type"], request.form["data"], request.form["admin_password"] )
@@ -627,7 +625,7 @@ def query():
 
     if request.args.get(admin_password) != eventlogger_config["admin_password"]:
         serviceutils.log_event("eventlogger_failed_attempt", {
-            "ip": request.remote_addr
+            "ip": get_remote_addr(request)
             })
 
     return event_logger.query( _type=_type, min_time=min_time, max_time=max_time, conditions=conditions, admin_password=request.args["admin_password"] )

--- a/api.py
+++ b/api.py
@@ -77,6 +77,17 @@ with open("resetPassword.html", 'r') as file:
 app = Flask(__name__)
 
 
+#Proxies 
+NUM_PROXIES = 1
+
+def get_remote_addr(request):
+    x_forwarded_for = request.headers.getlist("X-Forwarded-For")[0]
+
+    forward_list = x_forwarded_for.split(",")
+
+    return forward_list[-NUM_PROXIES]
+
+
 
 
 #Define app routes
@@ -113,7 +124,7 @@ def sign_up():
 @app.route("/auth/sign_in", methods=["GET", "POST"])
 def sign_in():
 
-    print(request.headers.getlist("X-Forwarded-For"))
+    print(get_remote_addr(request))
 
     if request.method == "POST":
 

--- a/api.py
+++ b/api.py
@@ -682,5 +682,5 @@ def send():
 
 
 if __name__ == '__main__':
-    app.wsgi_app = ProxyFix(app.wsgi_app)
+    app.wsgi_app = ProxyFix(app.wsgi_app, num_proxies=2)
     app.run(host='0.0.0.0')

--- a/api.py
+++ b/api.py
@@ -11,6 +11,7 @@ from services.Notifications import Notifications
 import serviceutils
 from urllib.parse import unquote
 from werkzeug.contrib.fixers import ProxyFix
+import os
 
 
 
@@ -122,7 +123,7 @@ def sign_in():
 
             serviceutils.log_event("sign_in_error", {
                         "error": result["error"],
-                        "ip": request.environ["REMOTE_ADDR"]
+                        "ip": os.environ["REMOTE_ADDR"]
                         })
 
         else:

--- a/api.py
+++ b/api.py
@@ -10,6 +10,9 @@ from services.EventLogger import EventLogger
 from services.Notifications import Notifications
 import serviceutils
 from urllib.parse import unquote
+from werkzeug.contrib.fixers import ProxyFix
+
+
 
 
 #MySQL server configuration
@@ -71,6 +74,8 @@ with open("resetPassword.html", 'r') as file:
 
 #Create flask app
 app = Flask(__name__)
+app.wsgi_app = ProxyFix(app.wsgi_app)
+
 
 
 
@@ -118,7 +123,7 @@ def sign_in():
 
             serviceutils.log_event("sign_in_error", {
                         "error": result["error"],
-                        "ip": request.remote_addr
+                        "ip": request.environ["REMOTE_ADDR"]
                         })
 
         else:
@@ -149,7 +154,7 @@ def password_reset(reset_id):
 
             serviceutils.log_event("error_in_reseting_password", {
                         "error": result["error"],
-                        "ip": request.remote_addr
+                        "ip": request.environ["REMOTE_ADDR"]
                         })
 
         return result
@@ -180,7 +185,7 @@ def verify_token():
         serviceutils.log_event("invalid_token", {
                     "error": result,
                     "false_token": token,
-                    "ip": request.remote_addr
+                    "ip": request.environ["REMOTE_ADDR"]
                     })
 
         return '{ "error": "' + result + '" }'

--- a/api.py
+++ b/api.py
@@ -113,7 +113,7 @@ def sign_up():
 @app.route("/auth/sign_in", methods=["GET", "POST"])
 def sign_in():
 
-    
+    print(request.headers.getlist("X-Forward-For"))
 
     if request.method == "POST":
 
@@ -123,7 +123,7 @@ def sign_in():
 
             serviceutils.log_event("sign_in_error", {
                         "error": result["error"],
-                        "ip": os.environ["REMOTE_ADDR"]
+                        "ip": request.environ["REMOTE_ADDR"]
                         })
 
         else:
@@ -683,5 +683,5 @@ def send():
 
 
 if __name__ == '__main__':
-    app.wsgi_app = ProxyFix(app.wsgi_app, num_proxies=2)
+    app.wsgi_app = ProxyFix(app.wsgi_app, num_proxies=3)
     app.run(host='0.0.0.0')


### PR DESCRIPTION
Our event logs were all giving `127.0.0.1` as the IP address for sign-ins. This is because of the proxy set up on app engine. This should fix it.