### PR TITLE
Fix token verification error

### DIFF
--- a/api.py
+++ b/api.py
@@ -410,7 +410,7 @@ def sethigh():
     verification = serviceutils.verify_token(token)
 
     if 'error' in verification:
-        return verification
+        return json.dumps( verification )
 
     uid = verification["uid"]
 
@@ -436,7 +436,7 @@ def setlow():
     verification = serviceutils.verify_token(token)
 
     if 'error' in verification:
-        return verification
+        return json.dumps( verification )
 
     uid = verification["uid"]
 
@@ -462,7 +462,7 @@ def like(highlowid):
 	verification = serviceutils.verify_token(token)
 
 	if 'error' in verification:
-		return verification
+		return json.dumps( verification )
 
 	else:
 		uid = verification["uid"]
@@ -483,7 +483,7 @@ def comment(highlowid):
 	verification = serviceutils.verify_token(token)
 
 	if 'error' in verification:
-		return verification
+		return json.dumps( verification )
 
 	else:
 		uid = verification["uid"]
@@ -507,7 +507,7 @@ def get_today():
 	verification = serviceutils.verify_token(token)
 
 	if 'error' in verification:
-		return verification
+		return json.dumps( verification )
 
 	else:
 		uid = verification["uid"]
@@ -528,7 +528,7 @@ def get_user():
 	verification = serviceutils.verify_token(token)
 
 	if 'error' in verification:
-		return verification
+		return json.dumps( verification )
 
 	else:
 		#Defaults to the current user

--- a/services/Auth.py
+++ b/services/Auth.py
@@ -202,7 +202,10 @@ class Auth:
     #Validate Token
     def validate_token(self, token):
 
-        payload = jwt.decode(token, self.SECRET_KEY, algorithms=["HS256"])
+        try:
+            payload = jwt.decode(token, self.SECRET_KEY, algorithms=["HS256"])
+        except:
+            return "ERROR-INVALID-TOKEN"
 
         current_timestamp = time.mktime( datetime.datetime.now().timetuple() )
 
@@ -345,7 +348,10 @@ class Auth:
         return token
 
     def refresh_access(self, refresh_token):
-        payload = jwt.decode(refresh_token, self.SECRET_KEY, algorithms=["HS256"])
+        try:
+            payload = jwt.decode(refresh_token, self.SECRET_KEY, algorithms=["HS256"])
+        except:
+            return "ERROR-INVALID-REFRESH-TOKEN"
 
         current_timestamp = time.mktime( datetime.datetime.now().timetuple() )
 


### PR DESCRIPTION
When I first coded the Auth class, I didn't realize PyJWT was smart enough to detect expired signatures, so I didn't catch the exception it causes when it finds one.

This patches that for both access token and refresh token verification.